### PR TITLE
Upload images in load_batch_from_csv

### DIFF
--- a/optimal_transport_morphometry/core/batch_parser.py
+++ b/optimal_transport_morphometry/core/batch_parser.py
@@ -1,10 +1,15 @@
 import csv
+from pathlib import Path
 from typing import TextIO
 from uuid import uuid4
 
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db import transaction
 
 from optimal_transport_morphometry.core import models
+
+root_dir = Path(__file__).parent.parent.parent
+images_dir = root_dir / 'sample_data' / 'images'
 
 
 @transaction.atomic
@@ -13,18 +18,35 @@ def load_batch_from_csv(csvfile: TextIO, dest: models.Dataset) -> models.UploadB
     batch = models.UploadBatch.objects.create(dataset=dest)
     patients = []
     uploads = []
+    images = []
 
     for row in reader:
         expected_name = row.pop('name')
-        patient_id = row.pop('patient', '').strip() or uuid4().hex
+        patient_id = row.pop('ID', '').strip() or uuid4().hex
         # TODO allow using existing patients too
-        patient = models.Patient(identifier=patient_id)
-        patients.append(patient)
+        patient, created = models.Patient.objects.get_or_create(identifier=patient_id)
+        if created:
+            patients.append(patient)
+
+        # Add uploads
         uploads.append(
             models.PendingUpload(batch=batch, patient=patient, name=expected_name, metadata=row)
         )
 
+        # Add image for corresponding row
+        with open(images_dir / expected_name, 'rb') as file_contents:
+            images.append(
+                models.Image(
+                    name=expected_name,
+                    dataset=dest,
+                    patient=patient,
+                    blob=SimpleUploadedFile(name=expected_name, content=file_contents.read()),
+                    metadata={'ID': patient_id},
+                )
+            )
+
     models.Patient.objects.bulk_create(patients)
     models.PendingUpload.objects.bulk_create(uploads)
+    models.Image.objects.bulk_create(images)
 
     return batch


### PR DESCRIPTION
Closes #24

This updates the `load_batch_from_csv` function to include the creation of images from the sample data. Now, preprocessing can be run on this dataset. Analysis is still failing (https://github.com/KitwareMedical/UTM/issues/1), but I'm not sure if it's related to this change.

@ebrahimebrahim ptal, I'm not totally confident that what I'm doing here is correct.