### PR TITLE
extend timeout for R package download

### DIFF
--- a/install.R
+++ b/install.R
@@ -41,4 +41,5 @@ binaries = c(
   "https://github.com/ANTsX/ANTsRCore/releases/download/v0.7.4.9/ANTsRCore_0.7.4.9_R_x86_64-pc-linux-gnu_R4.1.tar.gz",
   "https://github.com/ANTsX/ANTsR/releases/download/v0.5.7.4/ANTsR_0.5.7.4_R_x86_64-pc-linux-gnu_R4.1.tar.gz"
 )
+options(timeout=600) # allow more time for downloads to take place in the installation command below
 install.packages(pkgs = binaries, repo = NULL)


### PR DESCRIPTION
I was having `install.R` fail to install the ANTsRCore package because it timed out before the download could finish.
This should extend timeout from 1 min to 10 mins

Leaving as draft because I haven't actually tested it