### PR TITLE
Add RNifti dependency to install.R

### DIFF
--- a/install.R
+++ b/install.R
@@ -23,7 +23,8 @@ packages = c(
   "shinyBS",
   "yaml",
   "raster",
-  "DT"
+  "DT",
+  "RNifti"
 )
 install.packages(pkgs = packages)
 


### PR DESCRIPTION
Closes #111

Tested by building the celery docker image and running

```
library('RNifti')
```

without any errors.